### PR TITLE
feat(ai): add tools generic to UIMessage

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -15,7 +15,7 @@ Converts an array of messages from useChat into an array of CoreMessages that ca
 with the AI core functions (e.g. `streamText`).
  */
 export function convertToModelMessages<TOOLS extends ToolSet = never>(
-  messages: Array<Omit<UIMessage, 'id'>>,
+  messages: Array<Omit<UIMessage<any, any, TOOLS>, 'id'>>,
   options?: { tools?: TOOLS },
 ): ModelMessage[] {
   const tools = options?.tools ?? ({} as TOOLS);

--- a/packages/ai/src/ui/get-tool-invocations.ts
+++ b/packages/ai/src/ui/get-tool-invocations.ts
@@ -1,9 +1,13 @@
 import { ToolInvocation, ToolInvocationUIPart, UIMessage } from './ui-messages';
+import { ToolSet } from '../generate-text/tool-set';
 
-export function getToolInvocations(message: UIMessage): ToolInvocation[] {
+export function getToolInvocations<TOOLS extends ToolSet>(
+  message: UIMessage<any, any, TOOLS>,
+): ToolInvocation<TOOLS>[] {
   return message.parts
     .filter(
-      (part): part is ToolInvocationUIPart => part.type === 'tool-invocation',
+      (part): part is ToolInvocationUIPart<TOOLS> =>
+        part.type === 'tool-invocation',
     )
     .map(part => part.toolInvocation);
 }

--- a/packages/ai/src/ui/ui-messages.ts
+++ b/packages/ai/src/ui/ui-messages.ts
@@ -1,4 +1,7 @@
 import { ToolCall, ToolResult } from '@ai-sdk/provider-utils';
+import { ToolSet } from '../generate-text/tool-set';
+import { ToolCallUnion } from '../generate-text/tool-call';
+import { ToolResultUnion } from '../generate-text/tool-result';
 import { ValueOf } from '../util/value-of';
 
 /**
@@ -10,10 +13,10 @@ The step is used to track how to map an assistant UI message with many tool invo
 back to a sequence of LLM assistant/tool result message pairs.
 It is optional for backwards compatibility.
  */
-export type ToolInvocation =
-  | ({ state: 'partial-call' } & ToolCall<string, any>)
-  | ({ state: 'call' } & ToolCall<string, any>)
-  | ({ state: 'result' } & ToolResult<string, any, any>);
+export type ToolInvocation<TOOLS extends ToolSet = ToolSet> =
+  | ({ state: 'partial-call' } & Omit<ToolCallUnion<TOOLS>, 'type'>)
+  | ({ state: 'call' } & Omit<ToolCallUnion<TOOLS>, 'type'>)
+  | ({ state: 'result' } & Omit<ToolResultUnion<TOOLS>, 'type'>);
 
 /**
 The data types that can be used in the UI message for the UI message data parts.
@@ -26,6 +29,7 @@ AI SDK UI Messages. They are used in the client and to communicate between the f
 export interface UIMessage<
   METADATA = unknown,
   DATA_PARTS extends UIDataTypes = UIDataTypes,
+  TOOLS extends ToolSet = ToolSet,
 > {
   /**
 A unique identifier for the message.
@@ -52,13 +56,16 @@ User messages can have text parts and file parts.
 
 Assistant messages can have text, reasoning, tool invocation, and file parts.
    */
-  parts: Array<UIMessagePart<DATA_PARTS>>;
+  parts: Array<UIMessagePart<DATA_PARTS, TOOLS>>;
 }
 
-export type UIMessagePart<DATA_TYPES extends UIDataTypes> =
+export type UIMessagePart<
+  DATA_TYPES extends UIDataTypes,
+  TOOLS extends ToolSet = ToolSet,
+> =
   | TextUIPart
   | ReasoningUIPart
-  | ToolInvocationUIPart
+  | ToolInvocationUIPart<TOOLS>
   | SourceUrlUIPart
   | FileUIPart
   | DataUIPart<DATA_TYPES>
@@ -104,13 +111,13 @@ export type ReasoningUIPart = {
 /**
  * A tool invocation part of a message.
  */
-export type ToolInvocationUIPart = {
+export type ToolInvocationUIPart<TOOLS extends ToolSet = ToolSet> = {
   type: 'tool-invocation';
 
   /**
    * The tool invocation.
    */
-  toolInvocation: ToolInvocation;
+  toolInvocation: ToolInvocation<TOOLS>;
 };
 
 /**
@@ -159,6 +166,7 @@ export type StepStartUIPart = {
 export type CreateUIMessage<
   METADATA = unknown,
   DATA_TYPES extends UIDataTypes = UIDataTypes,
-> = Omit<UIMessage<METADATA, DATA_TYPES>, 'id'> & {
-  id?: UIMessage<METADATA, DATA_TYPES>['id'];
+  TOOLS extends ToolSet = ToolSet,
+> = Omit<UIMessage<METADATA, DATA_TYPES, TOOLS>, 'id'> & {
+  id?: UIMessage<METADATA, DATA_TYPES, TOOLS>['id'];
 };


### PR DESCRIPTION
## Summary
- type UIMessage now has a tools generic so tool invocation parts are typed
- update ToolInvocationUIPart and CreateUIMessage accordingly
- propagate tools generic in helpers

## Testing
- `pnpm install`
- `pnpm test` *(fails: run failed command exited 1)*

------
https://chatgpt.com/codex/tasks/task_e_68403c8ca194832ea97c95f82cf51baf