### PR TITLE
fix(ai): type-safe tool invocation parts

### DIFF
--- a/packages/ai/src/ui/convert-to-model-messages.ts
+++ b/packages/ai/src/ui/convert-to-model-messages.ts
@@ -14,8 +14,8 @@ import {
 Converts an array of messages from useChat into an array of CoreMessages that can be used
 with the AI core functions (e.g. `streamText`).
  */
-export function convertToModelMessages<TOOLS extends ToolSet = never>(
-  messages: Array<Omit<UIMessage, 'id'>>,
+export function convertToModelMessages<TOOLS extends ToolSet = ToolSet>(
+  messages: Array<Omit<UIMessage<any, any, TOOLS>, 'id'>>,
   options?: { tools?: TOOLS },
 ): ModelMessage[] {
   const tools = options?.tools ?? ({} as TOOLS);

--- a/packages/ai/src/ui/get-tool-invocations.ts
+++ b/packages/ai/src/ui/get-tool-invocations.ts
@@ -1,9 +1,13 @@
 import { ToolInvocation, ToolInvocationUIPart, UIMessage } from './ui-messages';
+import { ToolSet } from '../../core/generate-text/tool-set';
 
-export function getToolInvocations(message: UIMessage): ToolInvocation[] {
+export function getToolInvocations<TOOLS extends ToolSet>(
+  message: UIMessage<any, any, TOOLS>,
+): ToolInvocation<TOOLS>[] {
   return message.parts
     .filter(
-      (part): part is ToolInvocationUIPart => part.type === 'tool-invocation',
+      (part): part is ToolInvocationUIPart<TOOLS> =>
+        part.type === 'tool-invocation',
     )
     .map(part => part.toolInvocation);
 }


### PR DESCRIPTION
## Summary
- propagate toolset generics to UIMessage utilities
- ensure ToolInvocation parts use typed args and tool names
- update imports after moving to core tool types

## Testing
- `pnpm install`
- `pnpm type-check`
- `pnpm build:packages`


------
https://chatgpt.com/codex/tasks/task_e_68403c8ca194832ea97c95f82cf51baf